### PR TITLE
feat: Syndicate作成時にリードバンクの資格チェックを追加し、関連するテストケースを実装

### DIFF
--- a/src/main/java/com/example/syndicatelending/syndicate/service/SyndicateService.java
+++ b/src/main/java/com/example/syndicatelending/syndicate/service/SyndicateService.java
@@ -3,26 +3,38 @@ package com.example.syndicatelending.syndicate.service;
 import com.example.syndicatelending.syndicate.entity.Syndicate;
 import com.example.syndicatelending.syndicate.repository.SyndicateRepository;
 import com.example.syndicatelending.common.application.exception.ResourceNotFoundException;
+import com.example.syndicatelending.party.repository.InvestorRepository;
+import com.example.syndicatelending.party.entity.Investor;
+import com.example.syndicatelending.party.entity.InvestorType;
+import com.example.syndicatelending.common.application.exception.BusinessRuleViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @Transactional
 public class SyndicateService {
     private final SyndicateRepository syndicateRepository;
+    private final InvestorRepository investorRepository;
 
-    public SyndicateService(SyndicateRepository syndicateRepository) {
+    public SyndicateService(SyndicateRepository syndicateRepository, InvestorRepository investorRepository) {
         this.syndicateRepository = syndicateRepository;
+        this.investorRepository = investorRepository;
     }
 
     public Syndicate createSyndicate(Syndicate syndicate) {
         if (syndicateRepository.existsByName(syndicate.getName())) {
             throw new IllegalArgumentException("Syndicate name already exists: " + syndicate.getName());
         }
+        // --- LEAD_BANK資格チェック追加 ---
+        Long leadBankId = syndicate.getLeadBankId();
+        Investor leadBank = investorRepository.findById(leadBankId)
+                .orElseThrow(() -> new BusinessRuleViolationException("指定されたリードバンクが存在しません: id=" + leadBankId));
+        if (leadBank.getInvestorType() != InvestorType.LEAD_BANK) {
+            throw new BusinessRuleViolationException("指定されたリードバンクはLEAD_BANKの資格を持っていません: id=" + leadBankId);
+        }
+        // ---
         return syndicateRepository.save(syndicate);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure that only existing investors of type "LEAD_BANK" can be selected as the lead bank when creating a syndicate. Users will now receive clear error messages if the lead bank is invalid or does not exist.

- **Tests**
  - Added and updated tests to verify correct validation of the lead bank during syndicate creation, ensuring better reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->