### PR TITLE
fix: 現在の投資額が未初期化の場合にゼロから開始する処理を追加

### DIFF
--- a/backend/src/main/java/com/example/syndicatelending/party/entity/Investor.java
+++ b/backend/src/main/java/com/example/syndicatelending/party/entity/Investor.java
@@ -166,6 +166,10 @@ public class Investor {
 
     public void increaseInvestmentAmount(Money amount) {
         if (amount != null && amount.isPositiveOrZero()) {
+            // Null safety: 初期化されていない場合はゼロから開始
+            if (this.currentInvestmentAmount == null) {
+                this.currentInvestmentAmount = Money.zero();
+            }
             this.currentInvestmentAmount = this.currentInvestmentAmount.add(amount);
             this.updatedAt = LocalDateTime.now();
         }
@@ -173,6 +177,10 @@ public class Investor {
 
     public void decreaseInvestmentAmount(Money amount) {
         if (amount != null && amount.isPositiveOrZero()) {
+            // Null safety: 初期化されていない場合はゼロから開始
+            if (this.currentInvestmentAmount == null) {
+                this.currentInvestmentAmount = Money.zero();
+            }
             this.currentInvestmentAmount = this.currentInvestmentAmount.subtract(amount);
             this.updatedAt = LocalDateTime.now();
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating investment amounts to prevent errors if the current amount was previously unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->